### PR TITLE
Add TypeDoc API reference documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           cache: pnpm
 
       - name: Install JS dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,83 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          version: 10.27.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install JS dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.91.1"
+          targets: aarch64-linux-android
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk
+
+      - name: Setup just
+        uses: extractions/setup-just@v2
+
+      - name: Apply bdk-ffi patches
+        run: just submodule-apply-patch
+
+      - name: Install JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: zulu
+          java-version: "17"
+
+      - name: Accept Android SDK licenses
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null
+
+      - name: Generate TypeScript bindings
+        run: pnpm ubrn:android --config ubrn.config.yaml
+
+      - name: Setup Python (for Zensical)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Build full documentation site
+        run: just docs-build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          keep_files: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
-Changelog information can be found in the bdk-ffi repository: https://github.com/bitcoindevkit/bdk-ffi/blob/master/CHANGELOG.md
+## [Unreleased]
+
+- Add TypeDoc-generated API reference at `/api/` on the documentation site
+- Add `just api-docs` and `just docs-build` recipes
+- Add CI workflow to build and publish API docs to GitHub Pages
+
+Changelog information for bdk-ffi releases can be found in the bdk-ffi repository: https://github.com/bitcoindevkit/bdk-ffi/blob/master/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The code in this repository is mostly comprised of:
 
 The core Rust code that is exposed to the React Native language bindings actually resides in the [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi) repository. This repo pulls it in as a submodule.
 
-## Exploring the Example Apps
+## Exploring the API and Example Apps
 
-To take a look at the API exposed in this library, you can run our example applications. [Read the docs on this here](https://bitcoindevkit.github.io/bdk-rn/example-apps/), and [find our example apps here](https://github.com/thunderbiscuit/bdk-rn-example-apps).
+Browse the [API reference](https://bitcoindevkit.github.io/bdk-rn/api/) for all public classes, methods, and types. For hands-on usage walkthroughs, run our [example applications](https://github.com/thunderbiscuit/bdk-rn-example-apps). [Read the docs on example apps here](https://bitcoindevkit.github.io/bdk-rn/example-apps/).
 
 <br>
 

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 rm -rf ./site/*
-uv run zensical build
+just docs-build
 cd ./site/
 git init .
 git switch --create gh-pages

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,5 @@
+# API Reference
+
+Browse the auto-generated API reference for all public classes, methods, and types.
+
+**[Open API Reference →](../api/index.html)**

--- a/docs/build.md
+++ b/docs/build.md
@@ -59,3 +59,31 @@ just test-android
 3. Update tests: `cd tests && npm install`
 4. Add or modify tests in the tests
 5. Run the app and verify test results in logcat or in the emulator
+
+## Generating API Reference Docs
+
+The API reference is generated with [TypeDoc](https://typedoc.org/) from the
+TypeScript bindings produced by ubrn. You must generate the bindings first:
+
+```shell
+just submodule-init
+just submodule-apply-patch
+pnpm ubrn:android --config ubrn.config.yaml
+```
+
+Then build the API docs alone or the full site:
+
+```shell
+# API reference only → site/api/
+just api-docs
+
+# Full site (guides + API) → site/
+just docs-build
+```
+
+Preview the API reference by opening `site/api/index.html` in a browser.
+`just docs` serves the Zensical guides only; use a static server on `site/`
+to preview the combined site locally.
+
+Docs are deployed to GitHub Pages on push to `main` (once CI is in place),
+or manually via `./deploy-docs.sh`.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,3 +26,7 @@ To build the library and start testing locally, you must have:
 ## Additional Resources
 
 For more advanced information on how to build this library, see the [uniffi-bindgen-react-native documentation](https://jhugman.github.io/uniffi-bindgen-react-native/guides/rn/getting-started.html).
+
+## API Reference
+
+Browse the auto-generated [API reference](https://bitcoindevkit.github.io/bdk-rn/api/) for all public classes, methods, and types. Example apps (linked below) provide supplementary usage walkthroughs.

--- a/justfile
+++ b/justfile
@@ -80,6 +80,17 @@ build-tarball:
   pnpm pack
 
 [group("Docs")]
+[doc("Generate API reference docs. Requires: just submodule-apply-patch && pnpm ubrn:android first.")]
+api-docs:
+  ./node_modules/.bin/typedoc
+
+[group("Docs")]
+[doc("Build full documentation site (Zensical guides + TypeDoc API reference).")]
+docs-build:
+  uv run zensical build
+  ./node_modules/.bin/typedoc
+
+[group("Docs")]
 [doc("Serve the docs locally.")]
 docs:
   uv run zensical serve

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "jest",
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "api-docs": "typedoc",
     "clean": "del-cli android/build lib",
     "prepare": "bob build",
     "release": "release-it --only-version"
@@ -85,6 +86,7 @@
     "react-native-builder-bob": "^0.40.13",
     "release-it": "^17.10.0",
     "turbo": "^1.10.7",
+    "typedoc": "0.27.9",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       turbo:
         specifier: ^1.10.7
         version: 1.13.4
+      typedoc:
+        specifier: 0.27.9
+        version: 0.27.9(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -921,6 +924,9 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@gerrit0/mini-shiki@1.27.2':
+    resolution: {integrity: sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==}
+
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
 
@@ -1265,6 +1271,15 @@ packages:
     peerDependencies:
       release-it: ^17.0.0
 
+  '@shikijs/engine-oniguruma@1.29.2':
+    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+
+  '@shikijs/types@1.29.2':
+    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
 
@@ -1319,6 +1334,9 @@ packages:
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -1351,6 +1369,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2238,6 +2259,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -3398,6 +3423,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3491,6 +3519,9 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   macos-release@3.4.0:
     resolution: {integrity: sha512-wpGPwyg/xrSp4H4Db4xYSeAr6+cFQGHfspHzDUdYxswDnUW0L5Ov63UuJiSr8NMSpyaChO4u1n0MXUvVPtrN6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3510,12 +3541,19 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+    hasBin: true
+
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -4003,6 +4041,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4661,10 +4703,20 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typedoc@0.27.9:
+    resolution: {integrity: sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -5970,6 +6022,12 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@gerrit0/mini-shiki@1.27.2':
+    dependencies:
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
@@ -6593,6 +6651,18 @@ snapshots:
       - conventional-commits-filter
       - conventional-commits-parser
 
+  '@shikijs/engine-oniguruma@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/types@1.29.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sideway/address@4.1.5':
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -6652,6 +6722,10 @@ snapshots:
     dependencies:
       '@types/node': 25.8.0
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -6684,6 +6758,8 @@ snapshots:
   '@types/semver@7.7.1': {}
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7698,6 +7774,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@4.5.0: {}
 
   env-paths@2.2.1: {}
 
@@ -9156,6 +9234,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -9234,6 +9316,8 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  lunr@2.3.9: {}
+
   macos-release@3.4.0: {}
 
   make-dir@4.0.0:
@@ -9248,9 +9332,20 @@ snapshots:
 
   map-obj@4.3.0: {}
 
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   memoize-one@5.2.1: {}
 
@@ -9868,6 +9963,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -10640,7 +10737,18 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typedoc@0.27.9(typescript@5.9.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 1.27.2
+      lunr: 2.3.9
+      markdown-it: 14.2.0
+      minimatch: 9.0.9
+      typescript: 5.9.3
+      yaml: 2.9.0
+
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/typedoc-readme.md
+++ b/typedoc-readme.md
@@ -1,0 +1,21 @@
+# bdk-rn API Reference
+
+React Native language bindings for the [Bitcoin Development Kit](https://bitcoindevkit.org/).
+
+This reference is auto-generated from the TypeScript bindings produced by
+[uniffi-bindgen-react-native](https://github.com/jhugman/uniffi-bindgen-react-native),
+which in turn reflects the Rust API in [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi).
+
+## React Native-specific behavior
+
+The Electrum and Esplora blockchain client methods (`scan`, `fullScan`,
+`broadcast`) are **asynchronous** in this library (they return `Promise`).
+This differs from bdk-python and other bindings where these methods are
+synchronous. This is a deliberate patch applied to bdk-ffi for React Native
+compatibility.
+
+## Getting started
+
+See [Getting Started](https://bitcoindevkit.github.io/bdk-rn/overview/) for
+installation and setup. For usage examples, see the
+[example apps](https://bitcoindevkit.github.io/bdk-rn/examples/about/).

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/generated/bdk.ts"],
+  "out": "site/api",
+  "name": "bdk-rn API Reference",
+  "readme": "typedoc-readme.md",
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeExternals": true,
+  "exclude": [
+    "**/FfiConverter*",
+    "**/uniffiInit*",
+    "**/UniffiLib*",
+    "**/RustBuffer*",
+    "**/LiftReturn*",
+    "**/Lower*"
+  ],
+  "navigationLinks": {
+    "GitHub": "https://github.com/bitcoindevkit/bdk-rn",
+    "BDK Docs": "https://bitcoindevkit.org"
+  },
+  "tsconfig": "tsconfig.json",
+  "skipErrorChecking": true,
+  "includeVersion": true,
+  "sort": ["source-order"]
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,7 +14,7 @@ repo_name = "bitcoindevkit/bdk-rn"
 # The site_url is the canonical URL for your site. When building online
 # documentation you should set this.
 # Read more: https://zensical.org/docs/setup/basics/#site_url
-#site_url = "https://www.example.com/"
+site_url = "https://bitcoindevkit.github.io/bdk-rn/"
 
 # The copyright notice appears in the page footer and can contain an HTML
 # fragment.
@@ -42,6 +42,7 @@ nav = [
     { "Android" = "examples/android.md" },
     { "iOS" = "examples/ios.md" },
   ]},
+  { "API Reference" = "api-reference.md" },
 ]
 
 # With the "extra_css" option you can add your own CSS styling to customize


### PR DESCRIPTION
Issue #6 asked for API documentation tooling and workflow for the React Native bindings. The project had Zensical guide docs but no browsable API reference; integrators were pointed at example apps to discover the API.

This adds TypeDoc generation from the UniFFI-produced TypeScript bindings (with JSDoc propagated from bdk-ffi Rust doc comments), integrates the output at `/api/` on the existing GitHub Pages site, and adds `just api-docs` / `just docs-build` with a CI workflow to build and deploy on push to `master`.

The TypeDoc landing page lives in `typedoc-readme.md` at the repo root (outside `docs/`) so Zensical does not emit an orphan `/api-index/` page. The docs CI workflow uses pnpm 10.27.0 with a SHA-pinned `pnpm/action-setup` action, matching `packageManager` in `package.json`. It also runs on pull requests (build only; deploy is gated to push on `master`). Main CI still uses yarn; fixing that is a separate follow-up.

Closes #6

Tested with:
`just docs-build` — passed
All local verification checks (site output, Wallet JSDoc, orphan page absent, typedoc-readme content in API index) — passed