### PR TITLE
Bump submodule to v3.1.0 tag (5fa4898a)

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -17,7 +17,7 @@ cd bdk-ffi/
 git fetch --all
 git checkout <tag>
 cd ..
-just apply-submodule-patches
+just submodule-apply-patch
 just clean
 just build-tarball
 cd tests/

--- a/justfile
+++ b/justfile
@@ -45,7 +45,8 @@ submodule-regen-patch:
   && git diff --unified=3 HEAD -- bdk-ffi/Cargo.toml > ../patches/bdk-ffi-async-sync-cargo.patch \
   && git diff --unified=3 HEAD -- bdk-ffi/src/lib.rs > ../patches/bdk-ffi-async-sync-lib.patch \
   && git diff --unified=3 HEAD -- bdk-ffi/src/esplora.rs > ../patches/bdk-ffi-async-sync-esplora.patch \
-  && git diff --unified=3 HEAD -- bdk-ffi/src/electrum.rs > ../patches/bdk-ffi-async-sync-electrum.patch
+  && git diff --unified=3 HEAD -- bdk-ffi/src/electrum.rs > ../patches/bdk-ffi-async-sync-electrum.patch \
+  && git diff --unified=3 HEAD -- bdk-ffi/src/tests/tx_builder.rs > ../patches/bdk-ffi-async-sync-tests.patch
 
 [group("Submodule")]
 [doc("Apply the async-sync patches to the bdk-ffi submodule.")]
@@ -55,7 +56,8 @@ submodule-apply-patch:
   && git apply -C1 ../patches/bdk-ffi-async-sync-cargo.patch \
   && git apply -C1 ../patches/bdk-ffi-async-sync-lib.patch \
   && git apply -C1 ../patches/bdk-ffi-async-sync-esplora.patch \
-  && git apply -C1 ../patches/bdk-ffi-async-sync-electrum.patch
+  && git apply -C1 ../patches/bdk-ffi-async-sync-electrum.patch \
+  && git apply -C1 ../patches/bdk-ffi-async-sync-tests.patch
 
 [group("Build")]
 [doc("Build the tarball for Android only. Pass ABIs to override ubrn.config.yaml, e.g. `just build-tarball-android x86_64` for a CI emulator.")]

--- a/patches/bdk-ffi-async-sync-cargo.patch
+++ b/patches/bdk-ffi-async-sync-cargo.patch
@@ -1,16 +1,16 @@
 diff --git a/bdk-ffi/Cargo.toml b/bdk-ffi/Cargo.toml
-index 3f9fdc8..041b585 100644
+index 473d994..650f6cf 100644
 --- a/bdk-ffi/Cargo.toml
 +++ b/bdk-ffi/Cargo.toml
 @@ -1,5 +1,5 @@
  [package]
 -name = "bdk-ffi"
 +name = "bdkffi"
- version = "3.1.0-alpha.0"
+ version = "3.1.0"
  homepage = "https://bitcoindevkit.org"
  repository = "https://github.com/bitcoindevkit/bdk"
 @@ -21,6 +21,7 @@ bdk_electrum = { version = "0.24.0", default-features = false, features = ["use-
- bdk_kyoto = { version = "0.17.0" }
+ bdk_kyoto = { version = "0.17.1" }
  
  uniffi = { version = "=0.31.2", features = ["cli"]}
 +tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/patches/bdk-ffi-async-sync-electrum.patch
+++ b/patches/bdk-ffi-async-sync-electrum.patch
@@ -1,5 +1,5 @@
 diff --git a/bdk-ffi/src/electrum.rs b/bdk-ffi/src/electrum.rs
-index 57288c1..6106bd4 100644
+index 57288c1..a9d545d 100644
 --- a/bdk-ffi/src/electrum.rs
 +++ b/bdk-ffi/src/electrum.rs
 @@ -24,7 +24,7 @@ use std::time::Duration;
@@ -29,7 +29,7 @@ index 57288c1..6106bd4 100644
          &self,
          request: Arc<FullScanRequest>,
          stop_gap: u64,
-@@ -90,20 +90,22 @@ impl ElectrumClient {
+@@ -90,20 +90,28 @@ impl ElectrumClient {
              .take()
              .ok_or(ElectrumError::RequestAlreadyConsumed)?;
  
@@ -42,8 +42,12 @@ index 57288c1..6106bd4 100644
 +        let client = Arc::clone(&self.0);
 +        crate::run_async(async move {
 +            tokio::task::spawn_blocking(move || -> Result<Arc<Update>, ElectrumError> {
-+                let result: BdkFullScanResponse<KeychainKind> =
-+                    client.full_scan(request, stop_gap as usize, batch_size as usize, fetch_prev_txouts)?;
++                let result: BdkFullScanResponse<KeychainKind> = client.full_scan(
++                    request,
++                    stop_gap as usize,
++                    batch_size as usize,
++                    fetch_prev_txouts,
++                )?;
  
 -        let update = BdkUpdate {
 -            last_active_indices: full_scan_result.last_active_indices,
@@ -59,13 +63,15 @@ index 57288c1..6106bd4 100644
 +                })))
 +            })
 +            .await
-+            .map_err(|e| ElectrumError::Message { error_message: e.to_string() })?
++            .map_err(|e| ElectrumError::Message {
++                error_message: e.to_string(),
++            })?
 +        })
 +        .await
      }
  
      /// Sync a set of scripts with the blockchain (via an Electrum client) for the data specified and returns updates for bdk_chain data structures.
-@@ -121,7 +123,7 @@ impl ElectrumClient {
+@@ -121,7 +129,7 @@ impl ElectrumClient {
      ///
      /// If the scripts to sync are unknown, such as when restoring or importing a keychain that may
      /// include scripts that have been used, use full_scan with the keychain.
@@ -74,7 +80,7 @@ index 57288c1..6106bd4 100644
          &self,
          request: Arc<SyncRequest>,
          batch_size: u64,
-@@ -135,17 +137,22 @@ impl ElectrumClient {
+@@ -135,17 +143,24 @@ impl ElectrumClient {
              .take()
              .ok_or(ElectrumError::RequestAlreadyConsumed)?;
  
@@ -101,7 +107,9 @@ index 57288c1..6106bd4 100644
 +                })))
 +            })
 +            .await
-+            .map_err(|e| ElectrumError::Message { error_message: e.to_string() })?
++            .map_err(|e| ElectrumError::Message {
++                error_message: e.to_string(),
++            })?
 +        })
 +        .await
      }

--- a/patches/bdk-ffi-async-sync-esplora.patch
+++ b/patches/bdk-ffi-async-sync-esplora.patch
@@ -1,5 +1,5 @@
 diff --git a/bdk-ffi/src/esplora.rs b/bdk-ffi/src/esplora.rs
-index aa09051..7f4e1bf 100644
+index 6311df5..1c038d5 100644
 --- a/bdk-ffi/src/esplora.rs
 +++ b/bdk-ffi/src/esplora.rs
 @@ -48,7 +48,7 @@ impl EsploraClient {
@@ -11,30 +11,13 @@ index aa09051..7f4e1bf 100644
          &self,
          request: Arc<FullScanRequest>,
          stop_gap: u64,
-@@ -62,29 +62,23 @@ impl EsploraClient {
+@@ -62,17 +62,24 @@ impl EsploraClient {
              .take()
              .ok_or(EsploraError::RequestAlreadyConsumed)?;
  
 -        let result: BdkFullScanResponse<KeychainKind> =
--            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
--                self.0
-+        let client = self.0.clone();
-+        crate::run_async(async move {
-+            tokio::task::spawn_blocking(move || -> Result<Arc<Update>, EsploraError> {
-+                let result: BdkFullScanResponse<KeychainKind> = client
-                     .full_scan(request, stop_gap as usize, parallel_requests as usize)
--            }))
--            .map_err(|payload| {
--                let error_message = payload
--                    .downcast_ref::<String>()
--                    .map(String::as_str)
--                    .or_else(|| payload.downcast_ref::<&str>().copied())
--                    .unwrap_or("panic in esplora client")
--                    .to_string();
-+                    .map_err(EsploraError::from)?;
- 
--                EsploraError::Parsing { error_message }
--            })??;
+-            self.0
+-                .full_scan(request, stop_gap as usize, parallel_requests as usize)?;
 -
 -        let update = BdkUpdate {
 -            last_active_indices: result.last_active_indices,
@@ -43,6 +26,12 @@ index aa09051..7f4e1bf 100644
 -        };
 -
 -        Ok(Arc::new(Update(update)))
++        let client = self.0.clone();
++        crate::run_async(async move {
++            tokio::task::spawn_blocking(move || -> Result<Arc<Update>, EsploraError> {
++                let result: BdkFullScanResponse<KeychainKind> =
++                    client.full_scan(request, stop_gap as usize, parallel_requests as usize)?;
++
 +                Ok(Arc::new(Update(BdkUpdate {
 +                    last_active_indices: result.last_active_indices,
 +                    tx_update: result.tx_update,
@@ -50,13 +39,15 @@ index aa09051..7f4e1bf 100644
 +                })))
 +            })
 +            .await
-+            .map_err(|e| EsploraError::Parsing { error_message: e.to_string() })?
++            .map_err(|e| EsploraError::Parsing {
++                error_message: e.to_string(),
++            })?
 +        })
 +        .await
      }
  
      /// Sync a set of scripts, txids, and/or outpoints against Esplora.
-@@ -92,7 +86,7 @@ impl EsploraClient {
+@@ -80,7 +87,7 @@ impl EsploraClient {
      /// `request` provides the data required to perform a script-pubkey-based sync (see
      /// [`SyncRequest`]). `parallel_requests` specifies the maximum number of HTTP requests to make
      /// in parallel.
@@ -65,24 +56,11 @@ index aa09051..7f4e1bf 100644
          &self,
          request: Arc<SyncRequest>,
          parallel_requests: u64,
-@@ -105,28 +99,23 @@ impl EsploraClient {
+@@ -93,15 +100,23 @@ impl EsploraClient {
              .take()
              .ok_or(EsploraError::RequestAlreadyConsumed)?;
  
--        let result: BdkSyncResponse =
--            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
--                self.0.sync(request, parallel_requests as usize)
--            }))
--            .map_err(|payload| {
--                let error_message = payload
--                    .downcast_ref::<String>()
--                    .map(String::as_str)
--                    .or_else(|| payload.downcast_ref::<&str>().copied())
--                    .unwrap_or("panic in esplora client")
--                    .to_string();
--
--                EsploraError::Parsing { error_message }
--            })??;
+-        let result: BdkSyncResponse = self.0.sync(request, parallel_requests as usize)?;
 -
 -        let update = BdkUpdate {
 -            last_active_indices: BTreeMap::default(),
@@ -94,9 +72,7 @@ index aa09051..7f4e1bf 100644
 +        let client = self.0.clone();
 +        crate::run_async(async move {
 +            tokio::task::spawn_blocking(move || -> Result<Arc<Update>, EsploraError> {
-+                let result: BdkSyncResponse = client
-+                    .sync(request, parallel_requests as usize)
-+                    .map_err(EsploraError::from)?;
++                let result: BdkSyncResponse = client.sync(request, parallel_requests as usize)?;
 +
 +                Ok(Arc::new(Update(BdkUpdate {
 +                    last_active_indices: BTreeMap::default(),
@@ -105,7 +81,9 @@ index aa09051..7f4e1bf 100644
 +                })))
 +            })
 +            .await
-+            .map_err(|e| EsploraError::Parsing { error_message: e.to_string() })?
++            .map_err(|e| EsploraError::Parsing {
++                error_message: e.to_string(),
++            })?
 +        })
 +        .await
      }

--- a/patches/bdk-ffi-async-sync-tests.patch
+++ b/patches/bdk-ffi-async-sync-tests.patch
@@ -1,0 +1,15 @@
+diff --git a/bdk-ffi/src/tests/tx_builder.rs b/bdk-ffi/src/tests/tx_builder.rs
+index 902fbb5..a743e2e 100644
+--- a/bdk-ffi/src/tests/tx_builder.rs
++++ b/bdk-ffi/src/tests/tx_builder.rs
+@@ -90,7 +90,9 @@ fn create_and_sync_wallet() -> Wallet {
+         .unwrap()
+         .build()
+         .unwrap();
+-    let update = client.full_scan(full_scan_request, 10, 10).unwrap();
++    let update = crate::RUNTIME
++        .block_on(client.full_scan(full_scan_request, 10, 10))
++        .unwrap();
+     wallet.apply_update(update).unwrap();
+     println!("Wallet balance: {:?}", wallet.balance().total.to_sat());
+     wallet


### PR DESCRIPTION
This PR bumps the bdk-ffi submodule to its latest tag, `v3.1.0`, preparation for the 3.1.0 release of bdk-rn.

See [changelog here](https://github.com/bitcoindevkit/bdk-ffi/blob/v3.1.0/CHANGELOG.md) for details on the release.